### PR TITLE
Add accumulate to Sequence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Implemented optimized version of `reduce_by_key`
 * Implemented `count_by_key`
 * Implemented `count_by_value`
+* Implemented `accumulate`
 
 ## Release 1.0.0
 

--- a/functional/pipeline.py
+++ b/functional/pipeline.py
@@ -7,7 +7,6 @@ from __future__ import division, absolute_import
 from operator import mul, add
 import collections
 from functools import reduce
-from itertools import accumulate
 
 import json
 import csv
@@ -952,7 +951,8 @@ class Sequence(object):
         :param func: two parameter, associative accumulate function
         :return: accumulated values using func in sequence
         """
-        return _wrap(accumulate(self, func))
+        return self._transform(transformations.accumulate_t(func))
+
 
     def make_string(self, separator):
         """

--- a/functional/pipeline.py
+++ b/functional/pipeline.py
@@ -4,9 +4,10 @@ The pipeline module contains the transformations and actions API of PyFunctional
 
 from __future__ import division, absolute_import
 
-from operator import mul
+from operator import mul, add
 import collections
 from functools import reduce
+from itertools import accumulate
 
 import json
 import csv
@@ -937,6 +938,21 @@ class Sequence(object):
             return _wrap(reduce(func, self, initial[0]))
         else:
             raise ValueError('reduce takes exactly one optional parameter for initial value')
+
+    def accumulate(self, func=add):
+        """
+        Accumulate sequence of elements using func. API mirrors itertools.accumulate
+
+        >>> seq([1, 2, 3]).accumulate(lambda x, y: x + y)
+        [1, 3, 6]
+
+        >>> seq(['a', 'b', 'c']).accumulate()
+        ['a', 'ab', 'abc']
+
+        :param func: two parameter, associative accumulate function
+        :return: accumulated values using func in sequence
+        """
+        return _wrap(accumulate(self, func))
 
     def make_string(self, separator):
         """

--- a/functional/test/test_functional.py
+++ b/functional/test/test_functional.py
@@ -330,6 +330,15 @@ class TestPipeline(unittest.TestCase):
         self.assertEqual(seq([]).reduce(f, 1), 1)
         self.assertEqual(seq([0, 2]).reduce(f, 1), 3)
 
+    def test_accumulate(self):
+        f = lambda x, y: x + y
+        l_char = ["a", "b", "c"]
+        expect_char = ["a", "ab", "abc"]
+        l_num = [1, 2, 3]
+        expect_num = [1, 3, 6]
+        self.assertEqual(seq(l_char).accumulate(), expect_char)
+        self.assertEqual(seq(l_num).accumulate(), expect_num)
+
     def test_aggregate(self):
         f = lambda current, next_element: current + next_element
         l = self.seq([1, 2, 3, 4])

--- a/functional/test/test_functional.py
+++ b/functional/test/test_functional.py
@@ -663,7 +663,7 @@ class TestPipeline(unittest.TestCase):
     def test_average(self):
         l = [1, 2]
         self.assertEqual(1.5, self.seq(l).average())
-        self.assertEquals(4.5, self.seq(l).average(lambda x: x * 3))
+        self.assertEqual(4.5, self.seq(l).average(lambda x: x * 3))
 
     def test_set(self):
         l = [1, 1, 2, 2, 3]

--- a/functional/transformations.py
+++ b/functional/transformations.py
@@ -488,6 +488,41 @@ def reduce_by_key_t(func):
         None
     )
 
+def _accumulate(sequence, func):
+    """
+    Python2 accumulate implementation
+    """
+    it = iter(sequence)
+    try:
+        total = next(it)
+    except StopIteration:
+        return
+    yield total
+    for element in it:
+        total = func(total, element)
+        yield total
+
+def accumulate_impl(func, sequence):
+    """
+    Implementation for accumulate
+    :param sequence: sequence to accumulate
+    :param func: accumulate function
+    """
+    if six.PY3:
+        from itertools import accumulate
+        return accumulate(sequence, func)
+    else:
+        return _accumulate(sequence, func)
+
+def accumulate_t(func):
+    """
+    Transformation for Sequence.accumulate
+    """
+    return Transformation(
+        'accumulate({0})'.format(name(func)),
+        partial(accumulate_impl, func),
+        None
+    )
 
 def count_by_key_impl(sequence):
     """
@@ -515,7 +550,7 @@ def count_by_key_t():
 
 def count_by_value_impl(sequence):
     """
-    Implementaiton for count_by_value_t
+    Implementation for count_by_value_t
     :param sequence: sequence of values
     :return: counts by value
     """

--- a/functional/transformations.py
+++ b/functional/transformations.py
@@ -494,10 +494,7 @@ def _accumulate(sequence, func):
     https://docs.python.org/3/library/itertools.html#itertools.accumulate
     """
     iterator = iter(sequence)
-    try:
-        total = next(iterator)
-    except StopIteration:
-        return
+    total = next(iterator)
     yield total
     for element in iterator:
         total = func(total, element)

--- a/functional/transformations.py
+++ b/functional/transformations.py
@@ -490,15 +490,16 @@ def reduce_by_key_t(func):
 
 def _accumulate(sequence, func):
     """
-    Python2 accumulate implementation
+    Python2 accumulate implementation taken from
+    https://docs.python.org/3/library/itertools.html#itertools.accumulate
     """
-    it = iter(sequence)
+    iterator = iter(sequence)
     try:
-        total = next(it)
+        total = next(iterator)
     except StopIteration:
         return
     yield total
-    for element in it:
+    for element in iterator:
         total = func(total, element)
         yield total
 

--- a/functional/transformations.py
+++ b/functional/transformations.py
@@ -504,6 +504,7 @@ def _accumulate(sequence, func):
         yield total
 
 def accumulate_impl(func, sequence):
+    # pylint: disable=no-name-in-module
     """
     Implementation for accumulate
     :param sequence: sequence to accumulate

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-future==0.15.2
+future==0.16.0
 six==1.10.0
 dill==0.2.5
 bz2file==0.98


### PR DESCRIPTION
### Change Summary
- add `accumulate` method to `Sequence`
- mirrors `itertools.accumulate` API

### Why
The alternative is to use `fold_left` and then drop the initial value. I believe creating a running sum is a common enough operation to warrent its own implementation.
```
In [1]: from functional import seq
In [2]: seq(1, 2, 3).fold_left([0], lambda acc, curr: acc + [acc[-1] + curr]).tail()
Out[2]: [1, 3, 6]
```
versus
```
In [1]: from functional import seq
In [2]: seq(1, 2, 3).accumulate()
Out[2]: [1, 3, 6]
```