### PR TITLE
Loosen versions for requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ try:
 except (IOError, ImportError):
     long_description = open('README.md').read()
 
-common_install_requires = ['future==0.16.0', 'six==1.10.0', 'dill==0.2.5', 'tabulate==0.7.7']
+common_install_requires = ['future<=1.0.0', 'six<=2.0.0', 'dill==0.2.5', 'tabulate<=1.0.0']
 if sys.version_info.major == 2 or '__pypy__' in sys.builtin_module_names:
     compression_requires = ['bz2file==0.98', 'backports.lzma==0.0.6']
     install_requires = common_install_requires


### PR DESCRIPTION
Per #128, this PR knocks up the required versions to the current major releases.  This should still keep the required APIs intact while allowing more end client flexibility.