### PR TITLE
Catch StopIteration errors for Python 3.7 compatibility

### DIFF
--- a/functional/transformations.py
+++ b/functional/transformations.py
@@ -609,9 +609,12 @@ def grouped_impl(wrap, size, sequence):
     :return: grouped sequence
     """
     iterator = iter(sequence)
-    while True:
-        batch = islice(iterator, size)
-        yield list(chain((wrap(next(batch)),), batch))
+    try:
+        while True:
+            batch = islice(iterator, size)
+            yield list(chain((wrap(next(batch)),), batch))
+    except StopIteration:
+        return
 
 
 def grouped_t(wrap, size):


### PR DESCRIPTION
As I reported in the issue below, "improperly" used `StopIteration` exceptions are now converted into `RuntimeError`s and they can cause programs to crash. The fix is pretty simple, fortunately. Let me know if you have any questions or want me to change/add anything. Thanks!

Fixes #131 