### PR TITLE
Transformations: Reversed: added PRE_COMPUTE attribute to reverse transformation

### DIFF
--- a/functional/transformations.py
+++ b/functional/transformations.py
@@ -103,7 +103,7 @@ def reversed_t():
     Transformation for Sequence.reverse
     :return: transformation
     """
-    return Transformation('reversed', reversed, None)
+    return Transformation('reversed', reversed, [ExecutionStrategies.PRE_COMPUTE])
 
 
 def slice_t(start, until):


### PR DESCRIPTION
python `reverse` cannot be applied to an iterator, so this seemed the most sensible way to fix something like reported in https://github.com/EntilZha/PyFunctional/issues/136

This is supposed to be a hotfix suggestion. Clearly, tests for this kind of behavior would be warranted to address the issue completely.