### PR TITLE
Docstring of tail fixed

### DIFF
--- a/functional/pipeline.py
+++ b/functional/pipeline.py
@@ -318,7 +318,7 @@ class Sequence(object):
         """
         Returns the sequence, without its first element.
 
-        >>> seq([1, 2, 3]).init()
+        >>> seq([1, 2, 3]).tail()
         [2, 3]
 
         :return: sequence without first element


### PR DESCRIPTION
Example in `tail` methods was wrong:

Instead of `seq([1, 2, 3]).init()` example shold be `seq([1, 2, 3]).tail()`