### PR TITLE
Distinct now maintains order

### DIFF
--- a/functional/test/test_functional.py
+++ b/functional/test/test_functional.py
@@ -419,7 +419,9 @@ class TestPipeline(unittest.TestCase):
         result = s.distinct()
         self.assertEqual(result.size(), len(expect))
         for er in zip(expect, result):
-            self.assertEqual(er[0], er[1], "Order was not preserved after running distinct!")
+            self.assertEqual(
+                er[0], er[1], "Order was not preserved after running distinct!"
+            )
         for e in result:
             self.assertTrue(e in expect)
         self.assert_type(result)

--- a/functional/transformations.py
+++ b/functional/transformations.py
@@ -144,7 +144,11 @@ def distinct_t():
 
     def distinct(sequence):
         seen = set()
-        return iter([x for x in sequence if not (x in seen or seen.add(x))])
+        for element in sequence:
+            if element in seen:
+                continue
+            seen.add(element)
+            yield element
 
     return Transformation("distinct", distinct, None)
 


### PR DESCRIPTION
This is meant to address https://github.com/EntilZha/PyFunctional/issues/126

```python
>>> arr = seq([1,2,3,4]).map(lambda x: x*2).distinct().to_list()
>>> arr 
[2, 4, 6, 8]
```