### PR TITLE
docs: fix simple typo, sequenc -> sequence

### DIFF
--- a/functional/pipeline.py
+++ b/functional/pipeline.py
@@ -1387,7 +1387,7 @@ class Sequence(object):
         >>> seq([1, 2, 3]).list()
         [1, 2, 3]
 
-        :param n: Take n elements of sequence eif not None
+        :param n: Take n elements of sequence if not None
         :return: list of elements in sequence
         """
         return self.to_list(n=n)

--- a/functional/pipeline.py
+++ b/functional/pipeline.py
@@ -1387,7 +1387,7 @@ class Sequence(object):
         >>> seq([1, 2, 3]).list()
         [1, 2, 3]
 
-        :param n: Take n elements of sequenc eif not None
+        :param n: Take n elements of sequence eif not None
         :return: list of elements in sequence
         """
         return self.to_list(n=n)


### PR DESCRIPTION
There is a small typo in functional/pipeline.py.

Should read `sequence` rather than `sequenc`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md