### PR TITLE
Addressing Issue 158: Unexpected Sequence Wrapping from Grouped

### DIFF
--- a/functional/pipeline.py
+++ b/functional/pipeline.py
@@ -1266,7 +1266,7 @@ class Sequence(object):
         :param size: size of the partitions
         :return: sequence partitioned into groups of length size
         """
-        return self._transform(transformations.grouped_t(_wrap, size))
+        return self._transform(transformations.grouped_t(size))
 
     def sliding(self, size, step=1):
         """

--- a/functional/test/test_functional.py
+++ b/functional/test/test_functional.py
@@ -619,6 +619,38 @@ class TestPipeline(unittest.TestCase):
         self.assertTrue(is_iterable(l.grouped(2)))
         self.assertTrue(is_iterable(l.grouped(3)))
 
+    def test_grouped_returns_list_of_lists(self):
+        test_inputs = [
+            [i for i in "abcdefghijklmnop"],
+            [None for i in range(10)],
+            [i for i in range(10)],
+            [[i] for i in range(10)],
+            [{i} for i in range(10)],
+            [{i, i + 1} for i in range(10)],
+            [[i, i + 1] for i in range(10)],
+        ]
+
+        def gen_test(collection, group_size):
+            expected_type = type(collection[0])
+
+            types_after_grouping = (
+                seq(collection)
+                .grouped(group_size)
+                .flatten()
+                .map(lambda item: type(item))
+            )
+
+            err_msg = f"Typing was not maintained after grouping. An input of {collection} yielded output types of {set(types_after_grouping)} and not {expected_type} as expected."
+
+            return types_after_grouping.for_all(lambda t: t == expected_type), err_msg
+
+        for test_input in test_inputs:
+            for group_size in [1, 2, 4, 7]:
+                all_sub_collections_are_lists, err_msg = gen_test(
+                    test_input, group_size
+                )
+                self.assertTrue(all_sub_collections_are_lists, msg=err_msg)
+
     def test_sliding(self):
         l = self.seq([1, 2, 3, 4, 5, 6, 7])
         expect = [[1, 2], [2, 3], [3, 4], [4, 5], [5, 6], [6, 7]]

--- a/functional/transformations.py
+++ b/functional/transformations.py
@@ -564,10 +564,9 @@ def group_by_t(func):
     )
 
 
-def grouped_impl(wrap, size, sequence):
+def grouped_impl(size, sequence):
     """
     Implementation for grouped_t
-    :param wrap: wrap children values with this
     :param size: size of groups
     :param sequence: sequence to group
     :return: grouped sequence
@@ -576,20 +575,19 @@ def grouped_impl(wrap, size, sequence):
     try:
         while True:
             batch = islice(iterator, size)
-            yield list(chain((wrap(next(batch)),), batch))
+            yield list(chain((next(batch),), batch))
     except StopIteration:
         return
 
 
-def grouped_t(wrap, size):
+def grouped_t(size):
     """
     Transformation for Sequence.grouped
-    :param wrap: wrap children values with this
     :param size: size of groups
     :return: transformation
     """
     return Transformation(
-        "grouped({0})".format(size), partial(grouped_impl, wrap, size), None
+        "grouped({0})".format(size), partial(grouped_impl, size), None
     )
 
 


### PR DESCRIPTION
## Elements That are Lists in a Sequence Will Remain Lists When Grouped.

Much of the details around this PR can be found in [issue 158](https://github.com/EntilZha/PyFunctional/issues/158). I added a quick summary below to get everyone on the same page.

```python
from functional import seq
s = [[i,i+1] for i in range(10)]
for batch in seq(s).grouped(3):
    for item in batch:
        print(f'{item} -- {type(item)}')
```
Running the above code sample and printing the output (were it captured) will result in the following output.
```shell
[0, 1] -- <class 'functional.pipeline.Sequence'>
[1, 2] -- <class 'list'>
[2, 3] -- <class 'list'>
[3, 4] -- <class 'functional.pipeline.Sequence'>
[4, 5] -- <class 'list'>
[5, 6] -- <class 'list'>
[6, 7] -- <class 'functional.pipeline.Sequence'>
[7, 8] -- <class 'list'>
[8, 9] -- <class 'list'>
[9, 10] -- <class 'functional.pipeline.Sequence'>
```

The same check run with these changes produces the output below.
```shell
[0, 1] -- <class 'list'>
[1, 2] -- <class 'list'>
[2, 3] -- <class 'list'>
[3, 4] -- <class 'list'>
[4, 5] -- <class 'list'>
[5, 6] -- <class 'list'>
[6, 7] -- <class 'list'>
[7, 8] -- <class 'list'>
[8, 9] -- <class 'list'>
[9, 10] -- <class 'list'>
```

Special thanks to @evanw2 for his leg work on this issue. The discovery in the first place and all of the investigation made this a lot easier #ShouldersOfGiants.