### PR TITLE
Allow empty sequence expressions `seq()`, `pseq()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 ## Next Release
+* Allow empty sequence expressions `seq()`, `pseq()` (#159)
 
 ## Release 1.3.0
 * added precompute attribute to reverse transformation (#137)

--- a/functional/streams.py
+++ b/functional/streams.py
@@ -41,13 +41,11 @@ class Stream(object):
         """
         # pylint: disable=no-self-use
         engine = ExecutionEngine()
-        return self._parse_args(
-            args, engine, "seq() takes at least 1 argument ({0} given)"
-        )
+        return self._parse_args(args, engine)
 
-    def _parse_args(self, args, engine, error_message):
+    def _parse_args(self, args, engine):
         if len(args) == 0:
-            raise TypeError(error_message.format(len(args)))
+            return Sequence([], engine=engine, max_repr_items=self.max_repr_items)
         if len(args) == 1:
             try:
                 if type(args[0]).__name__ == "DataFrame":
@@ -304,9 +302,7 @@ class ParallelStream(Stream):
         engine = ParallelExecutionEngine(
             processes=processes, partition_size=partition_size
         )
-        return self._parse_args(
-            args, engine, "pseq() takes at least 1 argument ({0} given)"
-        )
+        return self._parse_args(args, engine)
 
 
 # pylint: disable=invalid-name

--- a/functional/test/test_functional.py
+++ b/functional/test/test_functional.py
@@ -663,6 +663,7 @@ class TestPipeline(unittest.TestCase):
 
     def test_empty(self):
         self.assertTrue(self.seq([]).empty())
+        self.assertEqual(self.seq(), self.seq([]))
 
     def test_non_empty(self):
         self.assertTrue(self.seq([1]).non_empty())
@@ -920,8 +921,7 @@ class TestPipeline(unittest.TestCase):
         self.assertIteratorEqual(self.seq(1, 2, 3), [1, 2, 3])
         self.assertIteratorEqual(self.seq(1), [1])
         self.assertIteratorEqual(self.seq(iter([1, 2, 3])), [1, 2, 3])
-        with self.assertRaises(TypeError):
-            self.seq()
+        self.assertIteratorEqual(self.seq(), [])
 
     def test_lineage_repr(self):
         s = self.seq(1).map(lambda x: x).filter(lambda x: True)


### PR DESCRIPTION
Issue: #159