### PR TITLE
Add "peek" feature, similar to that of Java Streams API

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,7 @@ Function | Description | Type
 `to_pandas(columns=None)` | Converts the sequence to a pandas DataFrame | action
 `cache()` | Forces evaluation of sequence immediately and caches the result | action
 `for_each(func)` | Executes `func` on each element of the sequence | action
+`peek(func)` | Executes `func` on each element of the sequence but returns the element | transformation
 
 ### Lazy Execution
 Whenever possible, `PyFunctional` will compute lazily. This is accomplished by tracking the list
@@ -411,11 +412,17 @@ undesirable to keep recomputing the same value. Below are some examples of inspe
 
 ```python
 def times_2(x):
-    print(x)
     return 2 * x
-elements = seq(1, 1, 2, 3, 4).map(times_2).distinct()
+
+elements = (
+   seq(1, 1, 2, 3, 4)
+      .map(times_2)
+      .peek(print)
+      .distinct()
+)
+
 elements._lineage
-# Lineage: sequence -> map(times_2) -> distinct
+# Lineage: sequence -> map(times_2) -> peek(print) -> distinct
 
 l_elements = elements.to_list()
 # Prints: 1
@@ -425,7 +432,7 @@ l_elements = elements.to_list()
 # Prints: 4
 
 elements._lineage
-# Lineage: sequence -> map(times_2) -> distinct -> cache
+# Lineage: sequence -> map(times_2) -> peek(print) -> distinct -> cache
 
 l_elements = elements.to_list()
 # The cached result is returned so times_2 is not called and nothing is printed
@@ -472,7 +479,7 @@ In order to be merged, all pull requests must:
 To learn more about me (the author) visit my webpage at
 [pedro.ai](https://www.pedro.ai).
 
-I created `PyFunctional` while using Python extensivel, and finding that I missed the
+I created `PyFunctional` while using Python extensively, and finding that I missed the
 ease of use for manipulating data that Spark RDDs and Scala collections have. The project takes the
 best ideas from these APIs as well as LINQ to provide an easy way to manipulate data when using
 Scala is not an option or PySpark is overkill.

--- a/functional/pipeline.py
+++ b/functional/pipeline.py
@@ -546,6 +546,21 @@ class Sequence(object):
         for e in self:
             func(e)
 
+    def peek(self, func):
+        """
+        Executes func on each element of the sequence and returns the element
+
+        >>> seq([1, 2, 3, 4]).peek(print).map(lambda x: x ** 2).to_list()
+        1
+        2
+        3
+        4
+        [1, 4, 9, 16]
+
+        :param func: function to execute
+        """
+        return self._transform(transformations.peek_t(func))
+
     def filter(self, func):
         """
         Filters sequence to include only elements where func is True.

--- a/functional/test/test_functional.py
+++ b/functional/test/test_functional.py
@@ -787,6 +787,17 @@ class TestPipeline(unittest.TestCase):
         self.seq(l).for_each(f)
         self.assertEqual(result, l)
 
+    def test_peek(self):
+        l = [1, 2, 3, "abc", {1: 2}, {1, 2, 3}]
+        result = []
+
+        def f(e):
+            result.append(e)
+
+        result_iter = self.seq(l).peek(f).list()
+        self.assertIteratorEqual(result_iter, l)
+        self.assertEqual(result, l)
+
     def test_exists(self):
         l = ["aaa", "BBB", "ccc"]
         self.assertTrue(self.seq(l).exists(str.islower))

--- a/functional/transformations.py
+++ b/functional/transformations.py
@@ -727,7 +727,5 @@ def peek_t(func):
     :return: transformation
     """
     return Transformation(
-        "peek({0})".format(name(func)),
-        partial(peek_impl, func),
-        None
+        "peek({0})".format(name(func)), partial(peek_impl, func), None
     )

--- a/functional/transformations.py
+++ b/functional/transformations.py
@@ -706,3 +706,28 @@ def join_t(other, join_type):
     return Transformation(
         "{0}_join".format(join_type), partial(join_impl, other, join_type), None
     )
+
+
+def peek_impl(func, sequence):
+    """
+    Implementation for peek_t
+    :param func: apply func
+    :param sequence: sequence to peek
+    :return: original sequence
+    """
+    for element in sequence:
+        func(element)
+        yield element
+
+
+def peek_t(func):
+    """
+    Transformation for Sequence.peek
+    :param func: peek function
+    :return: transformation
+    """
+    return Transformation(
+        "peek({0})".format(name(func)),
+        partial(peek_impl, func),
+        None
+    )


### PR DESCRIPTION
Here is a proposal for an idiomatic way to do a "peek" operation (https://www.baeldung.com/java-streams-peek-api). 

TL;DR: In Java, you can call .peek( someFn ) as an intermediate step in the pipeline, but it wouldn't modify the value like .map would.

```python
# for example
(
  seq(1, 2, 3)
  .map(lambda x: x ** 2)
  .peek(print)
  .to_set()
)
```

I think it could be helpful for logging / maintaining stats / debugging purposes.