### PR TITLE
Add the split transformation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## Next Release
 * Allow empty sequence expressions `seq()`, `pseq()` (#159)
 * Add `no_wrap` option to `head()`, `head_option()`, `first()`, `last()` and `last_option()`, as well as to `seq()`, `pseq()` and `Sequence` constructor
+* Add the `split` transformation
 
 ## Release 1.3.0
 * added precompute attribute to reverse transformation (#137)

--- a/functional/pipeline.py
+++ b/functional/pipeline.py
@@ -1383,6 +1383,16 @@ class Sequence(object):
         """
         return self._transform(transformations.slice_t(start, until))
 
+    def split(self, func):
+        """
+        Returns a sequence of list splitted by elements that return True given a func transform. The return
+        value of func must be boolean.
+
+        :param func: function to use for splitting the sequence, return True if you want a split at this element.
+        :return: sequence of lists
+        """
+        return self._transform(transformations.split_t(func))
+
     def to_list(self, n=None):
         """
         Converts sequence to list of elements.

--- a/functional/pipeline.py
+++ b/functional/pipeline.py
@@ -1385,8 +1385,8 @@ class Sequence(object):
 
     def split(self, func):
         """
-        Returns a sequence of list splitted by elements that return True given a func transform. The return
-        value of func must be boolean.
+        Returns a sequence of lists splitted by elements that return True given a func transform. 
+        The return value of func must be boolean.
 
         :param func: function to use for splitting the sequence, return True if you want a split at this element.
         :return: sequence of lists

--- a/functional/test/test_functional.py
+++ b/functional/test/test_functional.py
@@ -769,6 +769,20 @@ class TestPipeline(unittest.TestCase):
         self.assertIteratorEqual(expect, list(result))
         self.assert_type(result)
 
+    def test_split(self):
+        l = [1, 2, -2, 3, 4, -1, 3]
+        e = [[1, 2], [3, 4], [3]]
+        f = lambda x: x < 0
+        s = self.seq(l)
+        p = s.split(f)
+        self.assertIteratorEqual(e, list(p))
+        self.assert_type(p)
+
+        result = self.seq([[1, 2, 3], [4, 5, 6]]).flatten().partition(lambda x: x > 2)
+        expect = [[3, 4, 5, 6], [1, 2]]
+        self.assertIteratorEqual(expect, list(result))
+        self.assert_type(result)
+
     def test_cartesian(self):
         result = seq.range(3).cartesian(range(3)).list()
         self.assertListEqual(result, list(product(range(3), range(3))))

--- a/functional/test/test_functional.py
+++ b/functional/test/test_functional.py
@@ -778,11 +778,6 @@ class TestPipeline(unittest.TestCase):
         self.assertIteratorEqual(e, list(p))
         self.assert_type(p)
 
-        result = self.seq([[1, 2, 3], [4, 5, 6]]).flatten().partition(lambda x: x > 2)
-        expect = [[3, 4, 5, 6], [1, 2]]
-        self.assertIteratorEqual(expect, list(result))
-        self.assert_type(result)
-
     def test_cartesian(self):
         result = seq.range(3).cartesian(range(3)).list()
         self.assertListEqual(result, list(product(range(3), range(3))))

--- a/functional/transformations.py
+++ b/functional/transformations.py
@@ -729,3 +729,31 @@ def peek_t(func):
     return Transformation(
         "peek({0})".format(name(func)), partial(peek_impl, func), None
     )
+
+
+def split_impl(func, sequence):
+    """
+    Implementation for split_t
+    :param func: apply func
+    :param sequence: sequence to split
+    :return: splitted sequence
+    """
+    result = []
+    for element in sequence:
+        if func(element):
+            yield result
+            result = []
+        else:
+            result = [*result, element]
+    yield result
+
+
+def split_t(func):
+    """
+    Transformation for Sequence.split
+    :param func: split function
+    :return: transformation
+    """
+    return Transformation(
+        "peek({0})".format(name(func)), partial(split_impl, func), None
+    )


### PR DESCRIPTION
Hello everyone,

This is my first PR ever, but I'm willing to learn, so don't hesitate to be picky. 

I was doing the advent of code 2022 with a constraint to use only Pyfunctional so that I could learn the library. I was blocked on the first problem because I felt it was missing a split function. 

The goal of such a function is to take a sequence and split it into several lists given a function. The function maps over the sequence and splits if it returns `True` or continues if it returns `False`. 
An example is worth a million words, so here it is:

```python
seq([1,2,3,None,4,5,6,7,None,8,9]).split(lambda x: x is None) 
>>> seq([ [1,2,3], [4,5,6,7], [8,9] ])
```
I tried to respect the rules for PR, but if I missed something feel free to comment ;) 

Have a good day!
