### PR TITLE
Add `chain` sequence constructor

### DIFF
--- a/functional/streams.py
+++ b/functional/streams.py
@@ -5,6 +5,7 @@ import sqlite3 as sqlite3api
 import builtins
 
 from itertools import chain
+from typing import Iterable
 
 from functional.execution import ExecutionEngine, ParallelExecutionEngine
 from functional.pipeline import Sequence
@@ -52,6 +53,10 @@ class Stream(object):
         """
         Merge given the iterators firstly, then new the seq.
         """
+        for arg in args:
+            if not isinstance(arg, Iterable):
+                raise TypeError("The type of arg should be iterator.")
+
         merged = list(chain.from_iterable(args))
         return self(*merged, no_wrap=no_wrap, **kwargs)
 

--- a/functional/streams.py
+++ b/functional/streams.py
@@ -58,7 +58,7 @@ class Stream(object):
                 raise TypeError("The type of arg should be iterator.")
 
         merged = list(chain.from_iterable(args))
-        return self(*merged, no_wrap=no_wrap, **kwargs)
+        return self(merged, no_wrap=no_wrap, **kwargs)
 
     def _parse_args(self, args, engine, no_wrap=None):
         _no_wrap = default_value(no_wrap, self.no_wrap, False)

--- a/functional/streams.py
+++ b/functional/streams.py
@@ -4,6 +4,8 @@ import json as jsonapi
 import sqlite3 as sqlite3api
 import builtins
 
+from itertools import chain
+
 from functional.execution import ExecutionEngine, ParallelExecutionEngine
 from functional.pipeline import Sequence
 from functional.util import is_primitive, default_value
@@ -45,6 +47,13 @@ class Stream(object):
         return self._parse_args(
             args, engine, no_wrap=default_value(no_wrap, self.no_wrap, False)
         )
+
+    def chain(self, *args, no_wrap=None, **kwargs):
+        """
+        Merge given the iterators firstly, then new the seq.
+        """
+        merged = list(chain.from_iterable(args))
+        return self(*merged, no_wrap=no_wrap, **kwargs)
 
     def _parse_args(self, args, engine, no_wrap=None):
         _no_wrap = default_value(no_wrap, self.no_wrap, False)

--- a/functional/streams.py
+++ b/functional/streams.py
@@ -51,14 +51,13 @@ class Stream(object):
 
     def chain(self, *args, no_wrap=None, **kwargs):
         """
-        Merge given the iterators firstly, then new the seq.
+        Create a Sequence chaining multiple iterators.
         """
         for arg in args:
             if not isinstance(arg, Iterable):
                 raise TypeError("The type of arg should be iterator.")
 
-        merged = list(chain.from_iterable(args))
-        return self(merged, no_wrap=no_wrap, **kwargs)
+        return self(chain(*args), no_wrap=no_wrap, **kwargs)
 
     def _parse_args(self, args, engine, no_wrap=None):
         _no_wrap = default_value(no_wrap, self.no_wrap, False)

--- a/functional/test/test_streams.py
+++ b/functional/test/test_streams.py
@@ -64,6 +64,34 @@ class TestStreams(unittest.TestCase):
         data = [-5, -3, -1, 1, 3, 5, 7]
         self.assertListEqual(data, self.seq.range(-5, 8, 2).to_list())
 
+    def test_lazyiness(self):
+        def yielder():
+            nonlocal step
+            step += 1
+            yield 1
+            step += 1
+            yield 2
+
+        step = 0
+        sequence = iter(seq(yielder()).map(str))
+        assert (
+            step == 0
+            and next(sequence) == "1"
+            and step == 1
+            and next(sequence) == "2"
+            and step == 2
+        )
+
+        step = 0
+        sequence = iter(seq.chain(yielder()).map(str))
+        assert (
+            step == 0
+            and next(sequence) == "1"
+            and step == 1
+            and next(sequence) == "2"
+            and step == 2
+        )
+
     def test_chain(self):
         data_a = range(1, 5)
         data_b = range(6, 11)

--- a/functional/test/test_streams.py
+++ b/functional/test/test_streams.py
@@ -64,6 +64,32 @@ class TestStreams(unittest.TestCase):
         data = [-5, -3, -1, 1, 3, 5, 7]
         self.assertListEqual(data, self.seq.range(-5, 8, 2).to_list())
 
+    def test_chain(self):
+        data_a = range(1, 5)
+        data_b = range(6, 11)
+        self.assertEqual(
+            list(data_a) + list(data_b), self.seq.chain(data_a, data_b).to_list()
+        )
+
+        data_c = set(data_b)
+        self.assertEqual(
+            list(data_a) + list(data_c), self.seq.chain(data_a, data_c).to_list()
+        )
+
+        data_d = {"a": 1, "b": 2}
+        self.assertEqual(
+            list(data_a) + list(data_d.keys()), self.seq.chain(data_a, data_d).to_list()
+        )
+
+        def iter_func():
+            for i in range(10):
+                yield i
+
+        self.assertEqual(
+            list(data_a) + list(range(10)),
+            self.seq.chain(data_a, iter_func()).to_list(),
+        )
+
     def test_csv(self):
         result = self.seq.csv("functional/test/data/test.csv").to_list()
         expect = [["1", "2", "3", "4"], ["a", "b", "c", "d"]]

--- a/functional/test/test_streams.py
+++ b/functional/test/test_streams.py
@@ -81,14 +81,12 @@ class TestStreams(unittest.TestCase):
             list(data_a) + list(data_d.keys()), self.seq.chain(data_a, data_d).to_list()
         )
 
-        def iter_func():
-            for i in range(10):
-                yield i
+        self.assertEqual([], self.seq.chain().to_list())
 
-        self.assertEqual(
-            list(data_a) + list(range(10)),
-            self.seq.chain(data_a, iter_func()).to_list(),
-        )
+        with self.assertRaises(TypeError):
+            self.seq.chain(1, 2).to_list()
+
+        self.assertEqual(list(data_a), self.seq.chain(data_a).to_list())
 
     def test_csv(self):
         result = self.seq.csv("functional/test/data/test.csv").to_list()

--- a/functional/test/test_streams.py
+++ b/functional/test/test_streams.py
@@ -88,6 +88,8 @@ class TestStreams(unittest.TestCase):
 
         self.assertEqual(list(data_a), self.seq.chain(data_a).to_list())
 
+        self.assertEqual([1], self.seq.chain([1]).to_list())
+
     def test_csv(self):
         result = self.seq.csv("functional/test/data/test.csv").to_list()
         expect = [["1", "2", "3", "4"], ["a", "b", "c", "d"]]


### PR DESCRIPTION
Copy of #181 with test and fix for lazyness of `chain()`, removed changes on `setup.py`, added tests for lazyness.
Closes #181.