### PR TITLE
feature: type hinting for pipeline and transformation

### DIFF
--- a/functional/pipeline.py
+++ b/functional/pipeline.py
@@ -29,7 +29,7 @@ from functional import transformations
 from functional.execution import ExecutionStrategies
 
 
-TSequence = TypeVar("TSequence", covariant=True, bound="Sequence") 
+TSequence = TypeVar("TSequence", covariant=True, bound="Sequence")
 
 
 class Sequence(object):
@@ -39,7 +39,12 @@ class Sequence(object):
     """
 
     def __init__(
-        self, sequence: TSequence, transform=None, engine: ExecutionEngine=None, max_repr_items: int=None, no_wrap: bool=False
+        self,
+        sequence: TSequence,
+        transform=None,
+        engine: ExecutionEngine = None,
+        max_repr_items: int = None,
+        no_wrap: bool = False,
     ):
         # pylint: disable=protected-access
         """
@@ -230,7 +235,7 @@ class Sequence(object):
             self._lineage = Lineage(engine=self.engine)
         return self
 
-    def head(self, no_wrap: bool=False):
+    def head(self, no_wrap: bool = False):
         """
         Returns the first element of the sequence.
 
@@ -252,7 +257,7 @@ class Sequence(object):
         else:
             return _wrap(self.take(1)[0])
 
-    def first(self, no_wrap: bool=False):
+    def first(self, no_wrap: bool = False):
         """
         Returns the first element of the sequence.
 
@@ -271,7 +276,7 @@ class Sequence(object):
         """
         return self.head(no_wrap=no_wrap)
 
-    def head_option(self, no_wrap: bool=False):
+    def head_option(self, no_wrap: bool = False):
         """
         Returns the first element of the sequence or None, if the sequence is empty.
 
@@ -288,7 +293,7 @@ class Sequence(object):
             return None
         return self.head(no_wrap=no_wrap)
 
-    def last(self, no_wrap: bool=False):
+    def last(self, no_wrap: bool = False):
         """
         Returns the last element of the sequence.
 
@@ -310,7 +315,7 @@ class Sequence(object):
         else:
             return _wrap(self.sequence[-1])
 
-    def last_option(self, no_wrap: bool=False):
+    def last_option(self, no_wrap: bool = False):
         """
         Returns the last element of the sequence or None, if the sequence is empty.
 

--- a/functional/pipeline.py
+++ b/functional/pipeline.py
@@ -10,6 +10,8 @@ import csv
 import sqlite3
 import re
 
+from typing import TypeVar
+
 from tabulate import tabulate
 
 from functional.execution import ExecutionEngine
@@ -27,6 +29,9 @@ from functional import transformations
 from functional.execution import ExecutionStrategies
 
 
+TSequence = TypeVar("TSequence", covariant=True, bound="Sequence") 
+
+
 class Sequence(object):
     """
     Sequence is a wrapper around any type of sequence which provides access to common
@@ -34,7 +39,7 @@ class Sequence(object):
     """
 
     def __init__(
-        self, sequence, transform=None, engine=None, max_repr_items=None, no_wrap=None
+        self, sequence: TSequence, transform=None, engine: ExecutionEngine=None, max_repr_items: int=None, no_wrap: bool=False
     ):
         # pylint: disable=protected-access
         """
@@ -225,7 +230,7 @@ class Sequence(object):
             self._lineage = Lineage(engine=self.engine)
         return self
 
-    def head(self, no_wrap=None):
+    def head(self, no_wrap: bool=False):
         """
         Returns the first element of the sequence.
 
@@ -247,7 +252,7 @@ class Sequence(object):
         else:
             return _wrap(self.take(1)[0])
 
-    def first(self, no_wrap=None):
+    def first(self, no_wrap: bool=False):
         """
         Returns the first element of the sequence.
 
@@ -266,7 +271,7 @@ class Sequence(object):
         """
         return self.head(no_wrap=no_wrap)
 
-    def head_option(self, no_wrap=None):
+    def head_option(self, no_wrap: bool=False):
         """
         Returns the first element of the sequence or None, if the sequence is empty.
 
@@ -283,7 +288,7 @@ class Sequence(object):
             return None
         return self.head(no_wrap=no_wrap)
 
-    def last(self, no_wrap=None):
+    def last(self, no_wrap: bool=False):
         """
         Returns the last element of the sequence.
 
@@ -305,7 +310,7 @@ class Sequence(object):
         else:
             return _wrap(self.sequence[-1])
 
-    def last_option(self, no_wrap=None):
+    def last_option(self, no_wrap: bool=False):
         """
         Returns the last element of the sequence or None, if the sequence is empty.
 

--- a/functional/transformations.py
+++ b/functional/transformations.py
@@ -172,7 +172,7 @@ def distinct_by_t(func: Callable):
     return Transformation(f"distinct_by({name(func)})", distinct_by, None)
 
 
-def sorted_t(key=None, reverse: bool=False):
+def sorted_t(key=None, reverse: bool = False):
     """
     Transformation for Sequence.sorted
     :param key: key to sort by

--- a/functional/transformations.py
+++ b/functional/transformations.py
@@ -11,6 +11,7 @@ from itertools import (
 )
 import collections
 import types
+from collections.abc import Callable
 
 from functional.execution import ExecutionStrategies
 
@@ -24,7 +25,7 @@ Transformation = collections.namedtuple(
 CACHE_T = Transformation("cache", None, None)
 
 
-def name(function):
+def name(function: Callable):
     """
     Retrieve a pretty name for the function
     :param function: function to get name from
@@ -36,7 +37,7 @@ def name(function):
         return str(function)
 
 
-def map_t(func):
+def map_t(func: Callable):
     """
     Transformation for Sequence.map
     :param func: map function
@@ -49,7 +50,7 @@ def map_t(func):
     )
 
 
-def select_t(func):
+def select_t(func: Callable):
     """
     Transformation for Sequence.select
     :param func: select function
@@ -62,7 +63,7 @@ def select_t(func):
     )
 
 
-def starmap_t(func):
+def starmap_t(func: Callable):
     """
     Transformation for Sequence.starmap and Sequence.smap
     :param func: starmap function
@@ -75,7 +76,7 @@ def starmap_t(func):
     )
 
 
-def filter_t(func):
+def filter_t(func: Callable):
     """
     Transformation for Sequence.filter
     :param func: filter function
@@ -88,7 +89,7 @@ def filter_t(func):
     )
 
 
-def where_t(func):
+def where_t(func: Callable):
     """
     Transformation for Sequence.where
     :param func: where function
@@ -101,7 +102,7 @@ def where_t(func):
     )
 
 
-def filter_not_t(func):
+def filter_not_t(func: Callable):
     """
     Transformation for Sequence.filter_not
     :param func: filter_not function
@@ -122,7 +123,7 @@ def reversed_t():
     return Transformation("reversed", reversed, [ExecutionStrategies.PRE_COMPUTE])
 
 
-def slice_t(start, until):
+def slice_t(start: int, until: int):
     """
     Transformation for Sequence.slice
     :param start: start index
@@ -153,7 +154,7 @@ def distinct_t():
     return Transformation("distinct", distinct, None)
 
 
-def distinct_by_t(func):
+def distinct_by_t(func: Callable):
     """
     Transformation for Sequence.distinct_by
     :param func: distinct_by function
@@ -171,7 +172,7 @@ def distinct_by_t(func):
     return Transformation(f"distinct_by({name(func)})", distinct_by, None)
 
 
-def sorted_t(key=None, reverse=False):
+def sorted_t(key=None, reverse: bool=False):
     """
     Transformation for Sequence.sorted
     :param key: key to sort by
@@ -183,7 +184,7 @@ def sorted_t(key=None, reverse=False):
     )
 
 
-def order_by_t(func):
+def order_by_t(func: Callable):
     """
     Transformation for Sequence.order_by
     :param func: order_by function
@@ -196,7 +197,7 @@ def order_by_t(func):
     )
 
 
-def drop_right_t(n):
+def drop_right_t(n: int):
     """
     Transformation for Sequence.drop_right
     :param n: number to drop from right
@@ -213,7 +214,7 @@ def drop_right_t(n):
     )
 
 
-def drop_t(n):
+def drop_t(n: int):
     """
     Transformation for Sequence.drop
     :param n: number to drop from left
@@ -224,7 +225,7 @@ def drop_t(n):
     )
 
 
-def drop_while_t(func):
+def drop_while_t(func: Callable):
     """
     Transformation for Sequence.drop_while
     :param func: drops while func is true
@@ -233,7 +234,7 @@ def drop_while_t(func):
     return Transformation(f"drop_while({name(func)})", partial(dropwhile, func), None)
 
 
-def take_t(n):
+def take_t(n: int):
     """
     Transformation for Sequence.take
     :param n: number to take
@@ -242,7 +243,7 @@ def take_t(n):
     return Transformation(f"take({n})", lambda sequence: islice(sequence, 0, n), None)
 
 
-def take_while_t(func):
+def take_while_t(func: Callable):
     """
     Transformation for Sequence.take_while
     :param func: takes while func is True
@@ -251,7 +252,7 @@ def take_while_t(func):
     return Transformation(f"take_while({name(func)})", partial(takewhile, func), None)
 
 
-def flat_map_impl(func, sequence):
+def flat_map_impl(func: Callable, sequence):
     """
     Implementation for flat_map_t
     :param func: function to map
@@ -710,7 +711,7 @@ def peek_impl(func, sequence):
         yield element
 
 
-def peek_t(func):
+def peek_t(func: Callable):
     """
     Transformation for Sequence.peek
     :param func: peek function


### PR DESCRIPTION
Initial add of types to the sequence class and the functions of transformation module
This is an initial commit for #118

The Sequence class has a parameter of `no_wraps` which is a keyword argument. By all indications, this is a boolean but the default parameter used was None. This can lead to confusion if not properly understood, so type hints have been included to specify it as a boolean, and the default parameter has been changed from None to False. They would run the same way, but False is more semantically accurate in this context.

The typing module is deprecated in more recent versions of python, but generics still need to be carried out using `TypeVar` until python 3.12. For backward compatibility using `TypeVar` is preferable. 