### PR TITLE
fix name of transformations

### DIFF
--- a/functional/transformations.py
+++ b/functional/transformations.py
@@ -57,7 +57,7 @@ def select_t(func: Callable):
     :return: transformation
     """
     return Transformation(
-        "select({name(func)})",
+        f"select({name(func)})",
         partial(map, func),
         {ExecutionStrategies.PARALLEL},
     )
@@ -70,7 +70,7 @@ def starmap_t(func: Callable):
     :return: transformation
     """
     return Transformation(
-        "starmap({name(func)})",
+        f"starmap({name(func)})",
         partial(starmap, func),
         {ExecutionStrategies.PARALLEL},
     )


### PR DESCRIPTION
In working recently, I noticed the names of some of the transformations were off.
Took a look and discovered that the f-string wasn't properly handled. This PR fixes that