### PR TITLE
Publish with github action and git versioning

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -6,6 +6,7 @@ name: Python package
 on:
   push:
     branches: [master, dev]
+    tags: '*'
   pull_request:
     branches: [master]
 
@@ -39,5 +40,85 @@ jobs:
         run: poetry run mypy functional
         if: always()
       - uses: codecov/codecov-action@v1
+        # only upload coverage for one python version
+        if: matrix.python-version == '3.11'
         with:
           file: ./coverage.xml
+      - name: Install poetry-dynamic-versioning
+        run: python -m pip install "poetry-dynamic-versioning[plugin]"
+        if: matrix.python-version == '3.11'
+      - name: Build a binary wheel and a source tarball
+        if: matrix.python-version == '3.11'
+        run: poetry build
+      - name: Store the distribution packages
+        if: matrix.python-version == '3.11'
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+  publish-to-pypi:
+    name: >-
+      Publish Python 🐍 distribution 📦 to PyPI
+    if: ${{ startsWith(github.ref, 'refs/tags/') }} # only publish to PyPI on tag pushes
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/pyfunctional
+    permissions:
+      id-token: write # IMPORTANT: mandatory for trusted publishing
+
+    steps:
+      - name: Download all the dists
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+      - name: Publish distribution 📦 to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+  github-release:
+    name: >-
+      Sign the Python 🐍 distribution 📦 with Sigstore
+      and upload them to GitHub Release
+    if: ${{ startsWith(github.ref, 'refs/tags/') }} # only publish to GitHub Releases on tag pushes
+    needs:
+      - build
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write # IMPORTANT: mandatory for making GitHub Releases
+      id-token: write # IMPORTANT: mandatory for sigstore
+
+    steps:
+      - name: Download all the dists
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+      - name: Sign the dists with Sigstore
+        uses: sigstore/gh-action-sigstore-python@v2.1.1
+        with:
+          inputs: >-
+            ./dist/*.tar.gz
+            ./dist/*.whl
+      - name: Create GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: >-
+          gh release create
+          '${{ github.ref_name }}'
+          --repo '${{ github.repository }}'
+          --generate-notes
+      - name: Upload artifact signatures to GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        # Upload to GitHub Release using the `gh` CLI.
+        # `dist/` contains the built packages, and the
+        # sigstore-produced signatures and certificates.
+        run: >-
+          gh release upload
+          '${{ github.ref_name }}' dist/**
+          --repo '${{ github.repository }}'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,9 +47,12 @@ mypy = "^1.1.1"
 types-tabulate = "^0.9.0.3"
 pandas-stubs = "^2.0.3.230814"
 
+[tool.poetry-dynamic-versioning]
+enable = true
+
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning>=1.0.0,<2.0.0"]
+build-backend = "poetry_dynamic_versioning.backend"
 
 [tool.coverage.report]
 exclude_lines = [


### PR DESCRIPTION
- Makes use of git versioning with https://github.com/mtkennerly/poetry-dynamic-versioning
- Added build, publish to pypi(only when new tag is published) and gh release(only when new tag is published)
- Publish coverage only for one version of python since they overrode each other and uploading was slow



### After merging
Make sure to configure trusted publishing https://docs.pypi.org/trusted-publishers/adding-a-publisher/

```bash
git checkout master
git pull
git tag v1.5.1
git push origin tag v1.5.1
```

Issue: https://github.com/EntilZha/PyFunctional/issues/201