### PR TITLE
fix: fix type hint of .group_by()

### DIFF
--- a/functional/pipeline.py
+++ b/functional/pipeline.py
@@ -1081,7 +1081,7 @@ class Sequence(Generic[_T_co]):
 
     def group_by(
         self, func: Callable[[_T_co], _T]
-    ) -> Sequence[tuple[_T, Sequence[_T_co]]]:
+    ) -> Sequence[tuple[_T, list[_T_co]]]:
         """
         Group elements into a list of (Key, Value) tuples where func creates the key and maps
         to values matching that key.


### PR DESCRIPTION
This PR correct type hint of .group_by() method.

```diff
     def group_by(
         self, func: Callable[[_T_co], _T]
-    ) -> Sequence[tuple[_T, Sequence[_T_co]]]:
+    ) -> Sequence[tuple[_T, list[_T_co]]]:
```

#206 